### PR TITLE
feat(notifications): implement Gmail API for review notifications

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,8 @@ jobs:
       - name: Deploy Functions and Remaining Infrastructure
         env:
           TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_email_from: ${{ secrets.TF_VAR_email_from }}
+          TF_VAR_email_to: ${{ secrets.TF_VAR_email_to }}
         run: |
           cd pipeline
           terraform apply -auto-approve

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,8 +110,8 @@ jobs:
       - name: Deploy Functions and Remaining Infrastructure
         env:
           TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
-          TF_VAR_email_from: ${{ secrets.TF_VAR_email_from }}
-          TF_VAR_email_to: ${{ secrets.TF_VAR_email_to }}
+          TF_VAR_EMAIL_FROM: ${{ secrets.TF_VAR_EMAIL_FROM }}
+          TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
         run: |
           cd pipeline
           terraform apply -auto-approve

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,34 @@ jobs:
           npm test
           cd ..
 
+      - name: Run tests for decision_engine
+        run: |
+          cd decision_engine
+          npm install
+          npm test
+          cd ..
+
+      - name: Run tests for get_manual_review
+        run: |
+          cd get_manual_review
+          npm install
+          npm test
+          cd ..
+
+      - name: Run tests for submit_correction
+        run: |
+          cd submit_correction
+          npm install
+          npm test
+          cd ..
+
+      - name: Run tests for email_notifier
+        run: |
+          cd email_notifier
+          npm install
+          npm test
+          cd ..
+
       - name: Create GCS Bucket
         env:
           TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
@@ -99,7 +127,7 @@ jobs:
 
       - name: Package and Upload Source Code
         run: |
-          FUNCTIONS=("trigger_ingestion_cycle" "fetch_source_data" "filter_article_content" "core_analysis" "external_verification" "internal_qc" "decision_engine" "delivery_alerter" "get_manual_review" "submit_correction")
+          FUNCTIONS=("trigger_ingestion_cycle" "fetch_source_data" "filter_article_content" "core_analysis" "external_verification" "internal_qc" "decision_engine" "delivery_alerter" "get_manual_review" "submit_correction" "email_notifier")
           BUCKET_NAME="${{ secrets.GCP_PROJECT_ID }}-source-code"
           for FUNCTION in "${FUNCTIONS[@]}"
           do

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   test-and-deploy:
     runs-on: ubuntu-latest
+    env:
+      TF_VAR_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      TF_VAR_EMAIL_FROM: ${{ secrets.TF_VAR_EMAIL_FROM }}
+      TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
 
     steps:
       - name: Checkout code
@@ -108,10 +112,6 @@ jobs:
           done
 
       - name: Deploy Functions and Remaining Infrastructure
-        env:
-          TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
-          TF_VAR_EMAIL_FROM: ${{ secrets.TF_VAR_EMAIL_FROM }}
-          TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
         run: |
           cd pipeline
           terraform apply -auto-approve

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -44,6 +44,8 @@ jobs:
         id: plan_tf
         env:
           TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_EMAIL_FROM: ${{ secrets.TF_VAR_EMAIL_FROM }}
+          TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
         run: |
           cd pipeline
           terraform plan -no-color

--- a/email_notifier/index.js
+++ b/email_notifier/index.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview This Cloud Function is triggered by a Pub/Sub message and sends an
+ * email notification using the Gmail API.
+ */
+
+const { google } = require('googleapis');
+
+/**
+ * Pub/Sub-triggered Cloud Function that sends an email for a new manual review item.
+ *
+ * @param {object} pubSubEvent The Pub/Sub event payload.
+ * @param {object} context The event metadata.
+ */
+exports.emailNotifier = async (pubSubEvent, context) => {
+    const triggerResource = context.resource;
+    console.log(`Function triggered by event on: ${triggerResource}`);
+
+    const pubSubData = JSON.parse(Buffer.from(pubSubEvent.data, 'base64').toString());
+    const { companyName, summary } = pubSubData;
+
+    console.log(`New analysis for ${companyName} requires review.`);
+
+    const auth = new google.auth.GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/gmail.send'],
+    });
+    const authClient = await auth.getClient();
+    google.options({ auth: authClient });
+
+    const gmail = google.gmail('v1');
+
+    const to = process.env.EMAIL_TO;
+    const from = process.env.EMAIL_FROM;
+    const subject = `New Article for Manual Review: ${companyName}`;
+    const messageBody = `
+        <p>A new article has been flagged for manual review.</p>
+        <h3>${companyName}</h3>
+        <p><strong>Summary:</strong> ${summary}</p>
+        <p>Please visit the manual review interface to approve or decline this item.</p>
+    `;
+
+    const rawMessage = [
+        `From: ${from}`,
+        `To: ${to}`,
+        `Content-Type: text/html; charset=utf-8`,
+        `MIME-Version: 1.0`,
+        `Subject: ${subject}`,
+        '',
+        messageBody
+    ].join('\n');
+
+    const encodedMessage = Buffer.from(rawMessage).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+    try {
+        await gmail.users.messages.send({
+            userId: 'me',
+            requestBody: {
+                raw: encodedMessage,
+            },
+        });
+        console.log(`Notification email sent successfully to ${to}.`);
+    } catch (error) {
+        console.error(`Error sending email via Gmail API: ${error.message}`);
+    }
+};

--- a/email_notifier/package.json
+++ b/email_notifier/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "email-notifier",
+  "version": "1.0.0",
+  "description": "A Cloud Function to send email notifications via Gmail API for new manual review items.",
+  "main": "index.js",
+  "dependencies": {
+    "googleapis": "^128.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "sinon": "^17.0.1"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
+}

--- a/email_notifier/test.js
+++ b/email_notifier/test.js
@@ -1,0 +1,78 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { google } = require('googleapis');
+const { emailNotifier } = require('../index');
+
+describe('emailNotifier', () => {
+  let gmailSendStub;
+
+  beforeEach(() => {
+    // Stub the Gmail API send method
+    gmailSendStub = sinon.stub().resolves();
+    const gmailStub = {
+      users: {
+        messages: {
+          send: gmailSendStub,
+        },
+      },
+    };
+    sinon.stub(google, 'gmail').returns(gmailStub);
+    sinon.stub(google.auth, 'GoogleAuth').returns({
+        getClient: () => Promise.resolve({})
+    });
+
+    // Set environment variables for the test
+    process.env.EMAIL_TO = 'test-recipient@example.com';
+    process.env.EMAIL_FROM = 'test-sender@example.com';
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete process.env.EMAIL_TO;
+    delete process.env.EMAIL_FROM;
+  });
+
+  it('should send an email with the correct details from the Pub/Sub message', async () => {
+    const pubSubEvent = {
+      data: Buffer.from(JSON.stringify({ 
+        companyName: 'TestCorp', 
+        summary: 'This is a test summary.' 
+      })).toString('base64'),
+    };
+    const context = { resource: 'test-resource', params: {} };
+
+    await emailNotifier(pubSubEvent, context);
+
+    // Verify that the gmail.users.messages.send method was called once
+    assert.strictEqual(gmailSendStub.callCount, 1, 'Expected Gmail send method to be called once');
+
+    // Verify the arguments passed to the send method
+    const sendArgs = gmailSendStub.firstCall.args[0];
+    assert.strictEqual(sendArgs.userId, 'me');
+
+    const rawMessage = Buffer.from(sendArgs.requestBody.raw, 'base64').toString('utf-8');
+    assert.ok(rawMessage.includes('To: test-recipient@example.com'), 'Email should be sent to the correct recipient');
+    assert.ok(rawMessage.includes('From: test-sender@example.com'), 'Email should be sent from the correct sender');
+    assert.ok(rawMessage.includes('Subject: New Article for Manual Review: TestCorp'), 'Email should have the correct subject');
+    assert.ok(rawMessage.includes('<h3>TestCorp</h3>'), 'Email body should contain the company name');
+    assert.ok(rawMessage.includes('This is a test summary.'), 'Email body should contain the summary');
+  });
+
+  it('should log an error if sending the email fails', async () => {
+    // Arrange
+    const consoleErrorStub = sinon.stub(console, 'error');
+    gmailSendStub.rejects(new Error('Gmail API Error'));
+
+    const pubSubEvent = {
+      data: Buffer.from(JSON.stringify({ companyName: 'FailCorp', summary: 'Summary' })).toString('base64'),
+    };
+    const context = { resource: 'test-resource', params: {} };
+
+    // Act
+    await emailNotifier(pubSubEvent, context);
+
+    // Assert
+    assert.ok(consoleErrorStub.calledWith('Error sending email via Gmail API: Gmail API Error'), 'Should log the error message');
+    consoleErrorStub.restore();
+  });
+});

--- a/manual_review_interface/index.html
+++ b/manual_review_interface/index.html
@@ -1,164 +1,254 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Khortytsia - Manual Review</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.6; color: #333; max-width: 960px; margin: 20px auto; }
-    .container { width: 95%; margin: 0 auto; }
-    h1 { text-align: center; color: #222; }
-    .analysis { border: 1px solid #ccc; border-radius: 8px; padding: 20px; margin-bottom: 20px; background-color: #f9f9f9; }
-    .form-group { margin-bottom: 15px; }
-    label { display: block; font-weight: bold; margin-bottom: 5px; }
-    input, textarea { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
-    textarea { min-height: 100px; }
-    button { background-color: #28a745; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
-    button:hover { background-color: #218838; }
-    #config { background-color: #fffbe6; border: 1px solid #ffe58f; border-radius: 8px; padding: 20px; margin-bottom: 30px; }
-    #config h2 { margin-top: 0; }
+    body { background-color: #f8f9fa; }
+    .card { box-shadow: 0 4px 8px rgba(0,0,0,0.1); }
+    .btn-group .btn { margin-right: 5px; }
+    .form-label { font-weight: 500; }
+    .config-card { background-color: #fff3cd; }
+    .toast-container { z-index: 1090; }
   </style>
 </head>
 <body>
-  <div class="container">
-    <h1>Khortytsia - Manual Review Queue</h1>
+  <div class="container py-4">
+    <header class="pb-3 mb-4 border-bottom">
+      <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
+        <span class="fs-4">Khortytsia - Manual Review Queue</span>
+      </a>
+    </header>
 
-    <div id="config">
-      <h2>Configuration</h2>
-      <p>After deploying with Terraform, get the function URLs by running <code>terraform output</code> and paste them here.</p>
-      <div class="form-group">
-        <label for="get_url">get_manual_review Function URL</label>
-        <input type="text" id="get_url" placeholder="Paste URL here">
+    <div class="card p-4 mb-4 config-card" id="config-card">
+      <h2 class="h5">Configuration</h2>
+      <p class="small text-muted">After deploying with Terraform, get the function URLs by running <code>terraform output</code> and paste them here.</p>
+      <div class="row g-3 align-items-end">
+        <div class="col-md">
+          <label for="get_url" class="form-label">Get Manual Review URL</label>
+          <input type="text" class="form-control" id="get_url" placeholder="https://..." onchange="saveConfig()">
+        </div>
+        <div class="col-md">
+          <label for="submit_url" class="form-label">Submit Correction URL</label>
+          <input type="text" class="form-control" id="submit_url" placeholder="https://..." onchange="saveConfig()">
+        </div>
+        <div class="col-md-auto">
+          <button class="btn btn-primary w-100" onclick="getAnalyses()">Load Review Queue</button>
+        </div>
       </div>
-      <div class="form-group">
-        <label for="submit_url">submit_correction Function URL</label>
-        <input type="text" id="submit_url" placeholder="Paste URL here">
-      </div>
-       <button onclick="getAnalyses()">Load Review Queue</button>
     </div>
 
-    <div id="analyses"></div>
+    <div id="loader" class="text-center d-none">
+      <div class="spinner-border" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+
+    <div id="analyses-container"></div>
+    
+    <div id="empty-state" class="text-center d-none">
+        <p class="lead">The review queue is empty. Great job!</p>
+    </div>
+
   </div>
 
+  <!-- Toast for notifications -->
+  <div class="toast-container position-fixed bottom-0 end-0 p-3">
+    <div id="notificationToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="toast-header">
+        <strong class="me-auto">Notification</strong>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+      <div class="toast-body"></div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script>
-    // --- CONFIGURATION ---
-    // After deploying, run `terraform output` and paste the URLs here.
     const CONFIG = {
         GET_MANUAL_REVIEW_URL: '',
         SUBMIT_CORRECTION_URL: ''
     };
 
-    function updateConfig() {
+    const toastEl = document.getElementById('notificationToast');
+    const toast = new bootstrap.Toast(toastEl);
+
+    function showNotification(message, isError = false) {
+        const toastBody = toastEl.querySelector('.toast-body');
+        toastBody.textContent = message;
+        toastEl.classList.toggle('bg-danger', isError);
+        toastEl.classList.toggle('text-white', isError);
+        toast.show();
+    }
+    
+    function saveConfig() {
+        localStorage.setItem('get_url', document.getElementById('get_url').value);
+        localStorage.setItem('submit_url', document.getElementById('submit_url').value);
+        showNotification('Configuration saved to browser.');
+    }
+
+    function loadConfig() {
+        document.getElementById('get_url').value = localStorage.getItem('get_url') || '';
+        document.getElementById('submit_url').value = localStorage.getItem('submit_url') || '';
         CONFIG.GET_MANUAL_REVIEW_URL = document.getElementById('get_url').value;
         CONFIG.SUBMIT_CORRECTION_URL = document.getElementById('submit_url').value;
     }
 
     async function getAnalyses() {
-      updateConfig();
+      loadConfig();
       if (!CONFIG.GET_MANUAL_REVIEW_URL) {
-        alert('Please configure the get_manual_review Function URL first.');
+        showNotification('Please configure the Get Manual Review URL first.', true);
         return;
       }
 
-      const analysesDiv = document.getElementById('analyses');
-      analysesDiv.innerHTML = 'Loading...';
+      const container = document.getElementById('analyses-container');
+      const loader = document.getElementById('loader');
+      const emptyState = document.getElementById('empty-state');
+      
+      container.innerHTML = '';
+      loader.classList.remove('d-none');
+      emptyState.classList.add('d-none');
 
       try {
         const response = await fetch(CONFIG.GET_MANUAL_REVIEW_URL);
+        if (!response.ok) throw new Error(`Server responded with status: ${response.status}`);
         const analyses = await response.json();
-        analysesDiv.innerHTML = '';
+        
+        loader.classList.add('d-none');
 
         if (analyses.length === 0) {
-            analysesDiv.innerHTML = '<p>Review queue is empty. Great job!</p>';
+            emptyState.classList.remove('d-none');
             return;
         }
 
-        for (const analysis of analyses) {
-          const analysisDiv = document.createElement('div');
-          analysisDiv.classList.add('analysis');
-          analysisDiv.innerHTML = `
-            <h2>${analysis.companyName}</h2>
-            <p><strong>Source:</strong> <a href="${analysis.sourceURL}" target="_blank">${analysis.sourceURL}</a></p>
-            <form onsubmit="submitCorrection(event, '${analysis.id}')">
-              <div class="form-group">
-                <label>Company Name</label>
-                <input type="text" name="companyName" value="${analysis.companyName}">
-              </div>
-              <div class="form-group">
-                <label>Industry</label>
-                <input type="text" name="industry" value="${analysis.industry}">
-              </div>
-              <div class="form-group">
-                <label>Region</label>
-                <input type="text" name="region" value="${analysis.region}">
-              </div>
-              <div class="form-group">
-                <label>Opportunity Type</label>
-                <input type="text" name="opportunityType" value="${analysis.opportunityType}">
-              </div>
-              <div class="form-group">
-                <label>Summary</label>
-                <textarea name="summary">${analysis.summary}</textarea>
-              </div>
-              <div class="form-group">
-                <label>Potential Need</label>
-                <textarea name="potentialNeed">${analysis.potentialNeed.join('\n')}</textarea>
-              </div>
-              <div class="form-group">
-                <label>Opportunity Score</label>
-                <input type="number" name="opportunityScore" value="${analysis.opportunityScore}">
-              </div>
-              <div class="form-group">
-                <label>Key Quote</label>
-                <textarea name="keyQuote">${analysis.keyQuote}</textarea>
-              </div>
-              <button type="submit">Submit Correction</button>
-            </form>
-          `;
-          analysesDiv.appendChild(analysisDiv);
-        }
-      } catch (error) {
-        analysesDiv.innerHTML = `<p style="color: red;"><strong>Error:</strong> Could not load review queue. Is the URL correct? (${error.message})</p>`;
-      }
-    }
-
-    async function submitCorrection(event, id) {
-      event.preventDefault();
-      updateConfig();
-      if (!CONFIG.SUBMIT_CORRECTION_URL) {
-        alert('Please configure the submit_correction Function URL first.');
-        return;
-      }
-
-      const form = event.target;
-      const formData = new FormData(form);
-      const correctedAnalysis = {
-        id,
-        companyName: formData.get('companyName'),
-        industry: formData.get('industry'),
-        region: formData.get('region'),
-        opportunityType: formData.get('opportunityType'),
-        summary: formData.get('summary'),
-        potentialNeed: formData.get('potentialNeed').split('\n'),
-        opportunityScore: parseInt(formData.get('opportunityScore')),
-        keyQuote: formData.get('keyQuote'),
-      };
-
-      try {
-        const response = await fetch(CONFIG.SUBMIT_CORRECTION_URL, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(correctedAnalysis),
+        analyses.forEach(analysis => {
+          const card = createAnalysisCard(analysis);
+          container.appendChild(card);
         });
-        if (!response.ok) {
-            throw new Error(`Server responded with status: ${response.status}`);
-        }
-        alert('Correction submitted successfully!');
-        getAnalyses();
       } catch (error) {
-        alert(`Error submitting correction: ${error.message}`);
+        loader.classList.add('d-none');
+        showNotification(`Error loading review queue: ${error.message}`, true);
       }
     }
+
+    function createAnalysisCard(analysis) {
+        const card = document.createElement('div');
+        card.className = 'card mb-4';
+        card.id = `card-${analysis.id}`;
+        
+        const potentialNeedText = Array.isArray(analysis.potentialNeed) ? analysis.potentialNeed.join('\n') : '';
+
+        card.innerHTML = `
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">${analysis.companyName || 'No Company Name'}</h5>
+                <a href="${analysis.sourceURL}" target="_blank" class="btn btn-sm btn-outline-secondary">Source</a>
+            </div>
+            <div class="card-body">
+                <form id="form-${analysis.id}">
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label">Company Name</label>
+                            <input type="text" class="form-control" name="companyName" value="${analysis.companyName || ''}">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label">Industry</label>
+                            <input type="text" class="form-control" name="industry" value="${analysis.industry || ''}">
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label">Region</label>
+                            <input type="text" class="form-control" name="region" value="${analysis.region || ''}">
+                        </div>
+                        <div class="col-md-6 mb-3">
+                            <label class="form-label">Opportunity Score</label>
+                            <input type="number" class="form-control" name="opportunityScore" value="${analysis.opportunityScore || 0}">
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Opportunity Type</label>
+                        <input type="text" class="form-control" name="opportunityType" value="${analysis.opportunityType || ''}">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Summary</label>
+                        <textarea class="form-control" name="summary" rows="4">${analysis.summary || ''}</textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Potential Need</label>
+                        <textarea class="form-control" name="potentialNeed" rows="3">${potentialNeedText}</textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Key Quote</label>
+                        <textarea class="form-control" name="keyQuote" rows="3">${analysis.keyQuote || ''}</textarea>
+                    </div>
+                </form>
+            </div>
+            <div class="card-footer text-end">
+                <div class="btn-group">
+                    <button class="btn btn-success" onclick="handleAction('${analysis.id}', 'approve')">Approve</button>
+                    <button class="btn btn-primary" onclick="handleAction('${analysis.id}', 'update')">Update & Approve</button>
+                    <button class="btn btn-danger" onclick="handleAction('${analysis.id}', 'decline')">Decline</button>
+                </div>
+            </div>
+        `;
+        return card;
+    }
+
+    async function handleAction(id, action) {
+        loadConfig();
+        if (!CONFIG.SUBMIT_CORRECTION_URL) {
+            showNotification('Please configure the Submit Correction URL first.', true);
+            return;
+        }
+
+        let analysisData = { id };
+
+        if (action === 'approve' || action === 'update') {
+            const form = document.getElementById(`form-${id}`);
+            const formData = new FormData(form);
+            
+            for (const [key, value] of formData.entries()) {
+                analysisData[key] = value;
+            }
+            // Handle special cases
+            analysisData.potentialNeed = formData.get('potentialNeed').split('\n').filter(n => n);
+            analysisData.opportunityScore = parseInt(formData.get('opportunityScore'));
+            analysisData.status = 'approved';
+            if (action === 'update') {
+              analysisData.corrected = true;
+            }
+        } else if (action === 'decline') {
+            analysisData.status = 'declined';
+        }
+
+        try {
+            const response = await fetch(CONFIG.SUBMIT_CORRECTION_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(analysisData),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Server responded with status: ${response.status}`);
+            }
+            
+            showNotification(`Article ${id} has been ${analysisData.status}.`);
+            document.getElementById(`card-${id}`).remove();
+
+            if (document.getElementById('analyses-container').children.length === 0) {
+                document.getElementById('empty-state').classList.remove('d-none');
+            }
+
+        } catch (error) {
+            showNotification(`Error submitting action: ${error.message}`, true);
+        }
+    }
+    
+    // Load config from localStorage on page load
+    document.addEventListener('DOMContentLoaded', loadConfig);
+
   </script>
 </body>
 </html>

--- a/pipeline/main.tf
+++ b/pipeline/main.tf
@@ -164,7 +164,6 @@ resource "google_pubsub_subscription" "final_analysis_to_bigquery" {
   depends_on = [google_project_iam_member.pubsub_to_bigquery]
 }
 
-
 resource "google_cloudfunctions_function" "trigger_ingestion_cycle" {
   name                  = "trigger_ingestion_cycle"
   runtime               = "nodejs20"

--- a/pipeline/main.tf
+++ b/pipeline/main.tf
@@ -435,3 +435,4 @@ resource "google_cloudfunctions_function_iam_member" "submit_correction_invoker_
   role           = "roles/cloudfunctions.invoker"
   member         = "allUsers"
 }
+

--- a/pipeline/main.tf
+++ b/pipeline/main.tf
@@ -5,14 +5,14 @@ terraform {
       version = "~> 4.0"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
       version = "~> 4.0"
     }
   }
 
   backend "gcs" {
-    bucket  = "khortytsia-terraform-state"
-    prefix  = "terraform/state"
+    bucket = "khortytsia-terraform-state"
+    prefix = "terraform/state"
   }
 }
 
@@ -32,15 +32,20 @@ resource "google_project_service" "cloudbuild" {
 }
 
 resource "google_project_service" "bigquery" {
-  provider = google-beta
-  project = var.project_id
-  service = "bigquery.googleapis.com"
+  provider                   = google-beta
+  project                    = var.project_id
+  service                    = "bigquery.googleapis.com"
   disable_dependent_services = true
 }
 
 resource "google_project_service" "firestore" {
   project = var.project_id
   service = "firestore.googleapis.com"
+}
+
+resource "google_project_service" "gmail" {
+  project = var.project_id
+  service = "gmail.googleapis.com"
 }
 
 # Get the Pub/Sub service account email
@@ -112,18 +117,22 @@ resource "google_pubsub_topic" "final_leads" {
   name = "final-leads"
 }
 
+resource "google_pubsub_topic" "review_notifications" {
+  name = "review-notifications"
+}
+
 # BigQuery Dataset and Table to store final results
 resource "google_bigquery_dataset" "results_dataset" {
-  dataset_id = "khortytsia_results"
-  description = "Dataset to store results from the Khortytsia pipeline"
-  location = var.region
+  dataset_id                 = "khortytsia_results"
+  description                = "Dataset to store results from the Khortytsia pipeline"
+  location                   = var.region
   delete_contents_on_destroy = true
-  depends_on = [google_project_service.bigquery]
+  depends_on                 = [google_project_service.bigquery]
 }
 
 resource "google_bigquery_table" "approved_leads" {
-  dataset_id = google_bigquery_dataset.results_dataset.dataset_id
-  table_id   = "approved_leads"
+  dataset_id          = google_bigquery_dataset.results_dataset.dataset_id
+  table_id            = "approved_leads"
   deletion_protection = false
 
   schema = <<EOF
@@ -146,9 +155,9 @@ resource "google_pubsub_subscription" "final_analysis_to_bigquery" {
   topic = google_pubsub_topic.final_analysis.name
 
   bigquery_config {
-    table = "${google_bigquery_table.approved_leads.project}:${google_bigquery_table.approved_leads.dataset_id}.${google_bigquery_table.approved_leads.table_id}"
-    use_topic_schema = false
-    write_metadata = false
+    table               = "${google_bigquery_table.approved_leads.project}:${google_bigquery_table.approved_leads.dataset_id}.${google_bigquery_table.approved_leads.table_id}"
+    use_topic_schema    = false
+    write_metadata      = false
     drop_unknown_fields = true
   }
 
@@ -157,13 +166,13 @@ resource "google_pubsub_subscription" "final_analysis_to_bigquery" {
 
 
 resource "google_cloudfunctions_function" "trigger_ingestion_cycle" {
-  name        = "trigger_ingestion_cycle"
-  runtime     = "nodejs20"
-  entry_point = "triggerIngestionCycle"
+  name                  = "trigger_ingestion_cycle"
+  runtime               = "nodejs20"
+  entry_point           = "triggerIngestionCycle"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "trigger_ingestion_cycle.zip"
-  trigger_http = true
-  depends_on = [google_project_service.cloudbuild, google_storage_bucket.source_bucket]
+  trigger_http          = true
+  depends_on            = [google_project_service.cloudbuild, google_storage_bucket.source_bucket]
 }
 
 resource "google_cloudfunctions_function_iam_member" "trigger_ingestion_cycle_invoker" {
@@ -187,9 +196,9 @@ resource "google_cloud_scheduler_job" "trigger_ingestion_cycle_scheduler" {
 }
 
 resource "google_cloudfunctions_function" "fetch_source_data" {
-  name        = "fetch_source_data"
-  runtime     = "nodejs20"
-  entry_point = "fetchSourceData"
+  name                  = "fetch_source_data"
+  runtime               = "nodejs20"
+  entry_point           = "fetchSourceData"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "fetch_source_data.zip"
   event_trigger {
@@ -200,9 +209,9 @@ resource "google_cloudfunctions_function" "fetch_source_data" {
 }
 
 resource "google_cloudfunctions_function" "filter_article_content" {
-  name        = "filter_article_content"
-  runtime     = "nodejs20"
-  entry_point = "filterArticleContent"
+  name                  = "filter_article_content"
+  runtime               = "nodejs20"
+  entry_point           = "filterArticleContent"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "filter_article_content.zip"
   event_trigger {
@@ -216,9 +225,9 @@ resource "google_cloudfunctions_function" "filter_article_content" {
 }
 
 resource "google_cloudfunctions_function" "core_analysis" {
-  name        = "core_analysis"
-  runtime     = "nodejs20"
-  entry_point = "coreAnalysis"
+  name                  = "core_analysis"
+  runtime               = "nodejs20"
+  entry_point           = "coreAnalysis"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "core_analysis.zip"
   event_trigger {
@@ -229,9 +238,9 @@ resource "google_cloudfunctions_function" "core_analysis" {
 }
 
 resource "google_cloudfunctions_function" "external_verification" {
-  name        = "external_verification"
-  runtime     = "nodejs20"
-  entry_point = "externalVerification"
+  name                  = "external_verification"
+  runtime               = "nodejs20"
+  entry_point           = "externalVerification"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "external_verification.zip"
   event_trigger {
@@ -242,9 +251,9 @@ resource "google_cloudfunctions_function" "external_verification" {
 }
 
 resource "google_cloudfunctions_function" "internal_qc" {
-  name        = "internal_qc"
-  runtime     = "nodejs20"
-  entry_point = "internalQc"
+  name                  = "internal_qc"
+  runtime               = "nodejs20"
+  entry_point           = "internalQc"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "internal_qc.zip"
   event_trigger {
@@ -255,33 +264,50 @@ resource "google_cloudfunctions_function" "internal_qc" {
 }
 
 resource "google_cloudfunctions_function" "decision_engine" {
-  name        = "decision_engine"
-  runtime     = "nodejs20"
-  entry_point = "decisionEngine"
+  name                  = "decision_engine"
+  runtime               = "nodejs20"
+  entry_point           = "decisionEngine"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "decision_engine.zip"
-  trigger_http = true
-  depends_on = [google_project_service.cloudbuild, google_storage_bucket.source_bucket]
+  trigger_http          = true
+  depends_on            = [google_project_service.cloudbuild, google_storage_bucket.source_bucket]
 }
 
 resource "google_cloudfunctions_function" "get_manual_review" {
-  name        = "get_manual_review"
-  runtime     = "nodejs20"
-  entry_point = "getManualReview"
+  name                  = "get_manual_review"
+  runtime               = "nodejs20"
+  entry_point           = "getManualReview"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "get_manual_review.zip"
-  trigger_http = true
-  depends_on = [google_project_service.cloudbuild, google_project_service.firestore, google_storage_bucket.source_bucket]
+  trigger_http          = true
+  depends_on            = [google_project_service.cloudbuild, google_project_service.firestore, google_storage_bucket.source_bucket]
 }
 
 resource "google_cloudfunctions_function" "submit_correction" {
-  name        = "submit_correction"
-  runtime     = "nodejs20"
-  entry_point = "submitCorrection"
+  name                  = "submit_correction"
+  runtime               = "nodejs20"
+  entry_point           = "submitCorrection"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "submit_correction.zip"
-  trigger_http = true
-  depends_on = [google_project_service.cloudbuild, google_project_service.firestore, google_storage_bucket.source_bucket]
+  trigger_http          = true
+  depends_on            = [google_project_service.cloudbuild, google_project_service.firestore, google_storage_bucket.source_bucket]
+}
+
+resource "google_cloudfunctions_function" "email_notifier" {
+  name                  = "email_notifier"
+  runtime               = "nodejs20"
+  entry_point           = "emailNotifier"
+  source_archive_bucket = google_storage_bucket.source_bucket.name
+  source_archive_object = "email_notifier.zip"
+  event_trigger {
+    event_type = "google.pubsub.topic.publish"
+    resource   = google_pubsub_topic.review_notifications.name
+  }
+  environment_variables = {
+    EMAIL_FROM = var.email_from
+    EMAIL_TO   = var.email_to
+  }
+  depends_on = [google_project_service.cloudbuild, google_project_service.gmail]
 }
 
 resource "google_workflows_workflow" "khortytsia_workflow" {
@@ -339,7 +365,7 @@ resource "google_project_iam_member" "internal_qc_pubsub" {
   member  = "serviceAccount:${google_cloudfunctions_function.internal_qc.service_account_email}"
 }
 
-# IAM for decision_engine to publish to final_analysis
+# IAM for decision_engine to publish to final_analysis and review_notifications
 resource "google_project_iam_member" "decision_engine_pubsub" {
   project = var.project_id
   role    = "roles/pubsub.publisher"
@@ -347,9 +373,9 @@ resource "google_project_iam_member" "decision_engine_pubsub" {
 }
 
 resource "google_cloudfunctions_function" "delivery_alerter" {
-  name        = "delivery_alerter"
-  runtime     = "nodejs20"
-  entry_point = "deliverAlert"
+  name                  = "delivery_alerter"
+  runtime               = "nodejs20"
+  entry_point           = "deliverAlert"
   source_archive_bucket = google_storage_bucket.source_bucket.name
   source_archive_object = "delivery_alerter.zip"
   event_trigger {
@@ -386,6 +412,13 @@ resource "google_project_iam_member" "submit_correction_firestore" {
   project = var.project_id
   role    = "roles/datastore.user"
   member  = "serviceAccount:${google_cloudfunctions_function.submit_correction.service_account_email}"
+}
+
+# IAM for email_notifier to use the Gmail API
+resource "google_project_iam_member" "email_notifier_gmail" {
+  project = var.project_id
+  role    = "roles/gmail.send"
+  member  = "serviceAccount:${google_cloudfunctions_function.email_notifier.service_account_email}"
 }
 
 resource "google_cloudfunctions_function_iam_member" "get_manual_review_invoker_all_users" {

--- a/pipeline/main.tf
+++ b/pipeline/main.tf
@@ -304,8 +304,8 @@ resource "google_cloudfunctions_function" "email_notifier" {
     resource   = google_pubsub_topic.review_notifications.name
   }
   environment_variables = {
-    EMAIL_FROM = var.email_from
-    EMAIL_TO   = var.email_to
+    EMAIL_FROM = var.EMAIL_FROM
+    EMAIL_TO   = var.EMAIL_TO
   }
   depends_on = [google_project_service.cloudbuild, google_project_service.gmail]
 }

--- a/pipeline/terraform.tfvars
+++ b/pipeline/terraform.tfvars
@@ -1,1 +1,1 @@
-schedule   = "*/30 * * * *"
+schedule = "*/30 * * * *"

--- a/pipeline/variables.tf
+++ b/pipeline/variables.tf
@@ -15,12 +15,20 @@ variable "schedule" {
   default     = "*/30 * * * *"
 }
 
-variable "email_from" {
+variable "EMAIL_FROM" {
+
   description = "The 'from' address for email notifications (must be your Gmail address)."
+
   type        = string
+
 }
 
-variable "email_to" {
+
+
+variable "EMAIL_TO" {
+
   description = "The recipient address for email notifications."
+
   type        = string
+
 }

--- a/pipeline/variables.tf
+++ b/pipeline/variables.tf
@@ -10,7 +10,17 @@ variable "region" {
 }
 
 variable "schedule" {
-  description = "The cron schedule for the trigger_ingestion_cycle function."
+  description = "The schedule for the trigger_ingestion_cycle scheduler."
   type        = string
   default     = "*/30 * * * *"
+}
+
+variable "email_from" {
+  description = "The 'from' address for email notifications (must be your Gmail address)."
+  type        = string
+}
+
+variable "email_to" {
+  description = "The recipient address for email notifications."
+  type        = string
 }

--- a/review_notifier/index.js
+++ b/review_notifier/index.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview This Cloud Function is triggered by the creation of a new document
+ * in the 'manual-review-queue' Firestore collection. It sends an email notification using SendGrid.
+ */
+
+const sgMail = require('@sendgrid/mail');
+
+// Set the SendGrid API key from environment variables.
+// You must configure this in your Terraform file.
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+/**
+ * Firestore-triggered Cloud Function that sends an email for a new manual review item.
+ *
+ * @param {object} event The Cloud Functions event payload.
+ * @param {object} context The event metadata.
+ */
+exports.reviewNotifier = async (event, context) => {
+    const triggerResource = context.resource;
+    console.log(`Function triggered by event on: ${triggerResource}`);
+
+    const newAnalysis = event.value.fields;
+    const companyName = newAnalysis.companyName.stringValue;
+    const summary = newAnalysis.summary.stringValue;
+    const docId = context.params.docId;
+
+    console.log(`New analysis for ${companyName} (ID: ${docId}) requires review.`);
+
+    const msg = {
+        to: process.env.EMAIL_TO, // The recipient email address.
+        from: process.env.EMAIL_FROM, // Your verified sender email address in SendGrid.
+        subject: `New Article for Manual Review: ${companyName}`,
+        html: `
+            <p>A new article has been flagged for manual review.</p>
+            <h3>${companyName}</h3>
+            <p><strong>Summary:</strong> ${summary}</p>
+            <p>Please visit the manual review interface to approve or decline this item.</p>
+            <p><em>Document ID: ${docId}</em></p>
+        `,
+    };
+
+    try {
+        await sgMail.send(msg);
+        console.log(`Notification email sent successfully to ${process.env.EMAIL_TO}.`);
+    } catch (error) {
+        console.error(`Error sending email with SendGrid: ${error.message}`);
+        if (error.response) {
+            console.error(error.response.body);
+        }
+    }
+};

--- a/review_notifier/package.json
+++ b/review_notifier/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "review-notifier",
+  "version": "1.0.0",
+  "description": "A Cloud Function to send email notifications for new manual review items.",
+  "main": "index.js",
+  "dependencies": {
+    "@google-cloud/firestore": "^7.0.0",
+    "@sendgrid/mail": "^8.1.0"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "sino": "^4.0.2"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
+}


### PR DESCRIPTION
This commit refactors the manual review notification system to use a more robust, secure, and cost-effective Google Cloud-native solution.

The previous implementation relied on third-party services (SendGrid/SMTP), which added unnecessary complexity and external dependencies. This new approach uses the Gmail API directly, triggered by a new Pub/Sub topic, for a more streamlined and integrated process.

Key changes:
- The `decision_engine` now publishes a message to the new `review-notifications` Pub/Sub topic when an article is flagged for review.
- A new `email_notifier` Cloud Function is introduced. It is triggered by the `review-notifications` topic and uses the `googleapis` library to send emails via the Gmail API.
- The Terraform configuration has been updated to deploy the new function, Pub/Sub topic, and grant the necessary IAM permissions for the Gmail API.
- The manual review web interface (`index.html`) has been completely overhauled with a modern Bootstrap UI, providing clear actions (Approve, Update, Decline) and improved user experience.