### PR TITLE
fix(tf): align terraform variable GCP_PROJECT_ID with CI

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Terraform Plan
         id: plan_tf
         env:
-          TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           TF_VAR_EMAIL_FROM: ${{ secrets.TF_VAR_EMAIL_FROM }}
           TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
         run: |

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           terraform_version: 1.2.5
 
+      - name: Remove Terraform lock file
+        run: gsutil rm gs://khortytsia-terraform-state/terraform/state/default.tflock || true
+
       - name: Validate Terraform
         id: validate_tf
         run: |
@@ -48,7 +51,7 @@ jobs:
           TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
         run: |
           cd pipeline
-          terraform plan -no-color
+          terraform plan -no-color -lock-timeout=300s
 
       - name: Run Unit & Security Tests for All Modules
         id: run_tests

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -33,9 +33,6 @@ jobs:
         with:
           terraform_version: 1.2.5
 
-      - name: Remove Terraform lock file
-        run: gsutil rm gs://khortytsia-terraform-state/terraform/state/default.tflock || true
-
       - name: Validate Terraform
         id: validate_tf
         run: |
@@ -51,7 +48,7 @@ jobs:
           TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
         run: |
           cd pipeline
-          terraform plan -no-color -lock-timeout=300s
+          terraform plan -no-color
 
       - name: Run Unit & Security Tests for All Modules
         id: run_tests

--- a/pipeline/variables.tf
+++ b/pipeline/variables.tf
@@ -1,4 +1,4 @@
-variable "project_id" {
+variable "GCP_PROJECT_ID" {
   description = "The GCP project ID."
   type        = string
 }


### PR DESCRIPTION
This change renames the `project_id` variable to `GCP_PROJECT_ID` in the Terraform configuration to match the environment variable being passed from the GitHub Actions workflow.

This resolves the "No value for required variable" error during `terraform apply`.