### PR TITLE
fix(ci): correct terraform project id variable in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   test-and-deploy:
     runs-on: ubuntu-latest
     env:
-      TF_VAR_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      TF_VAR_GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       TF_VAR_EMAIL_FROM: ${{ secrets.TF_VAR_EMAIL_FROM }}
       TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
 


### PR DESCRIPTION
This PR fixes the variable name for the GCP Project ID in the main.yml workflow file to align with the terraform configuration.