### PR TITLE
feat(trigger_ingestion_cycle): externalize data sources

### DIFF
--- a/trigger_ingestion_cycle/data-sources.json
+++ b/trigger_ingestion_cycle/data-sources.json
@@ -1,0 +1,16 @@
+[
+  { "source_url": "https://www.bloomberg.com/", "source_type": "Scrape" },
+  { "source_url": "https://techcrunch.com/", "source_type": "Scrape" },
+  { "source_url": "https://www.wired.com/", "source_type": "Scrape" },
+  { "source_url": "https://hbr.org/", "source_type": "Scrape" },
+  { "source_url": "https://www.forbes.com/", "source_type": "Scrape" },
+  { "source_url": "https://www.wsj.com/", "source_type": "Scrape" },
+  { "source_url": "https://www.trendhunter.com/", "source_type": "Scrape" },
+  { "source_url": "https://explodingtopics.com/", "source_type": "Scrape" },
+  { "source_url": "https://www.wipo.int/global_innovation_index/en/", "source_type": "Scrape" },
+  { "source_url": "https://site.financialmodelingprep.com/developer/docs", "source_type": "API" },
+  { "source_url": "https://www.cognism.com/api", "source_type": "API" },
+  { "source_url": "https://coresignal.com/developers/api-documentation", "source_type": "API" },
+  { "source_url": "https://platform.openai.com/docs/api-reference", "source_type": "API" },
+  { "source_url": "https://cloud.google.com/apis/docs/overview", "source_type": "API" }
+]

--- a/trigger_ingestion_cycle/index.js
+++ b/trigger_ingestion_cycle/index.js
@@ -8,26 +8,7 @@ const { PubSub } = require('@google-cloud/pubsub');
 const pubsub = new PubSub();
 const topicName = 'source-to-fetch';
 
-// In a production environment, this list would likely be stored in a database or a configuration file.
-// TODO: Move dataSources to a managed database or configuration service
-const dataSources = [
-  // News & Trend Websites (for scraping)
-  { source_url: 'https://www.bloomberg.com/', source_type: 'Scrape' },
-  { source_url: 'https://techcrunch.com/', source_type: 'Scrape' },
-  { source_url: 'https://www.wired.com/', source_type: 'Scrape' },
-  { source_url: 'https://hbr.org/', source_type: 'Scrape' },
-  { source_url: 'https://www.forbes.com/', source_type: 'Scrape' },
-  { source_url: 'https://www.wsj.com/', source_type: 'Scrape' },
-  { source_url: 'https://www.trendhunter.com/', source_type: 'Scrape' },
-  { source_url: 'https://explodingtopics.com/', source_type: 'Scrape' },
-  { source_url: 'https://www.wipo.int/global_innovation_index/en/', source_type: 'Scrape' },
-  // APIs (for direct data goodness)
-  { source_url: 'https://site.financialmodelingprep.com/developer/docs', source_type: 'API' },
-  { source_url: 'https://www.cognism.com/api', source_type: 'API' },
-  { source_url: 'https://coresignal.com/developers/api-documentation', source_type: 'API' },
-  { source_url: 'https://platform.openai.com/docs/api-reference', source_type: 'API' },
-  { source_url: 'https://cloud.google.com/apis/docs/overview', source_type: 'API' }
-];
+const dataSources = require('./data-sources.json');
 /**
  * An HTTP-triggered Cloud Function that kicks off the data ingestion process.
  *

--- a/trigger_ingestion_cycle/test/test.js
+++ b/trigger_ingestion_cycle/test/test.js
@@ -36,7 +36,9 @@ describe('triggerIngestionCycle', () => {
     expect(res.status.calledWith(200)).to.be.true;
     expect(res.send.calledWith('Ingestion cycle triggered successfully.')).to.be.true;
 
+const dataSources = require('../data-sources.json');
+
     // Check that a message was published for each data source
-    expect(publishMessageMock.callCount).to.equal(14); // 14 data sources in the mock
+    expect(publishMessageMock.callCount).to.equal(dataSources.length);
   });
 });


### PR DESCRIPTION
This PR addresses issue #34 by externalizing the data sources for the `trigger_ingestion_cycle` function into a `data-sources.json` file. This resolves the original intent of issue #33.