### PR TITLE
feat(ci): add temporary workflow to import terraform state

### DIFF
--- a/.github/workflows/import-state.yml
+++ b/.github/workflows/import-state.yml
@@ -1,0 +1,48 @@
+name: Import Existing Infrastructure
+
+on:
+  workflow_dispatch:
+
+jobs:
+  import-state:
+    runs-on: ubuntu-latest
+    env:
+      TF_VAR_GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      TF_VAR_EMAIL_TO: ${{ secrets.TF_VAR_EMAIL_TO }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Authenticate to Google Cloud
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.2.5
+
+      - name: Terraform Init
+        id: init
+        run: |
+          cd pipeline
+          terraform init -reconfigure
+
+      - name: Import Resources
+        id: import
+        run: |
+          cd pipeline
+          terraform import module.storage.google_storage_bucket.source_bucket ${{ secrets.GCP_PROJECT_ID }}-source-code || echo "Failed to import source_bucket. It may not exist."
+          terraform import module.bigquery.google_bigquery_dataset.results_dataset ${{ secrets.GCP_PROJECT_ID }}:khortytsia_results || echo "Failed to import results_dataset. It may not exist."
+          terraform import module.monitoring.google_logging_metric.metric manual_review_required_metric || echo "Failed to import manual_review_metric. It may not exist."
+          for topic in $(gcloud pubsub topics list --format='value(name)' --filter='name:projects/${{ secrets.GCP_PROJECT_ID }}/topics/'); do
+            topic_name=$(basename $topic)
+            terraform import module.pubsub.google_pubsub_topic.topics["$topic_name"] $topic_name || echo "Failed to import topic $topic_name. It may not exist."
+          done


### PR DESCRIPTION
This PR adds a temporary, manually-triggered workflow to fix the Terraform state by importing existing resources. After merging this, please run the 'Import Existing Infrastructure' workflow from the Actions tab on GitHub. This should resolve the 'resource already exists' errors in the main deployment pipeline. Once the state is fixed and a deployment is successful, this workflow file should be deleted.